### PR TITLE
- Added a new command-line argument `--fetch-metadata` to trigger this functionality.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ You can use `tag_album.py` to update the album and artist tags of all MP3 files 
 | `-y`, `--year`  | Sets the year (e.g., 2023) for the MP3 files |
 | `--show`         | Displays the current metadata of the MP3 files                   |
 | `--html`         | Outputs the metadata in HTML format                              |
+| `--fetch-metadata` | Fetches metadata (album artist, track numbers, year, cover art) from MusicBrainz for MP3 files. Uses existing artist and album tags to search. |
 | `-R`, `--recursive` | Recursively process files in subdirectories. If not set, only files in the specified folder (non-recursive) are processed. |
 | `-h`, `--help`   | Shows the help message and exits.                                |
 
@@ -51,6 +52,14 @@ You can use `tag_album.py` to update the album and artist tags of all MP3 files 
 - **Recursively update album for all MP3s in a folder and its subfolders:**
   ```sh
   python tag_album.py -f /path/to/folder -a "New Album for All" -R
+  ```
+- **Fetch metadata from MusicBrainz for all MP3s in a folder (requires existing artist and album tags):**
+  ```sh
+  python tag_album.py -f /path/to/your/music --fetch-metadata
+  ```
+- **Fetch metadata recursively:**
+  ```sh
+  python tag_album.py -f /path/to/your/music --fetch-metadata -R
   ```
 - **Show the help message:**
   ```sh

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 mutagen
 prettytable
 yattag
+musicbrainzngs

--- a/tag_album.py
+++ b/tag_album.py
@@ -12,7 +12,9 @@ from mutagen.id3 import ID3, ID3NoHeaderError
 from prettytable import PrettyTable
 from yattag import Doc
 import datetime
-
+import musicbrainzngs
+import requests # For fetching cover art
+from mutagen.id3 import APIC, TALB, TPE1, TPE2, TRCK, TYER, USLT # Added specific ID3 frames
 
 def show_folder_tags_in_pretty_HTML(directory, recursive):
     """
@@ -457,6 +459,165 @@ def set_year_tag(directory, year_value, recursive):
     write_log(log_entries, "year_tagging")
 
 
+def fetch_metadata_from_musicbrainz(file_path, log_entries_list):
+    """
+    Fetches metadata from MusicBrainz for a given MP3 file and updates its ID3 tags.
+
+    Args:
+        file_path (str): The path to the MP3 file.
+        log_entries_list (list): A list to append log messages to.
+    """
+    try:
+        audio = EasyID3(file_path)
+    except ID3NoHeaderError:
+        log_entries_list.append(f"Skipping {file_path}: No ID3 header found to read artist/album.")
+        return
+    except Exception as e:
+        log_entries_list.append(f"Skipping {file_path}: Error reading initial tags: {e}")
+        return
+
+    artist = audio.get('artist', [None])[0]
+    album = audio.get('album', [None])[0]
+
+    if not artist or not album:
+        log_entries_list.append(f"Skipping {file_path}: Artist or Album tag not found.")
+        return
+
+    log_entries_list.append(f"Processing {file_path}: Artist='{artist}', Album='{album}'")
+
+    # Configure musicbrainzngs (replace with your app details)
+    musicbrainzngs.set_useragent("tag-album-script", "0.1", "http://example.com/tag-album-script")
+
+    try:
+        # Search for the release
+        # Note: 'release' is preferred over 'album' for MusicBrainz terminology for actual album releases
+        result = musicbrainzngs.search_releases(artist=artist, release=album, limit=5)
+
+        if not result['release-list']:
+            log_entries_list.append(f"No results found on MusicBrainz for {artist} - {album} in {file_path}.")
+            return
+
+        # Assume the first result is the best match for now
+        # More sophisticated matching could be added here (e.g., checking track count, year)
+        release = result['release-list'][0]
+        release_id = release['id']
+        log_entries_list.append(f"Found release: {release['title']} ({release_id}) with score {release['ext:score']}%")
+
+        # Get detailed release information, including recordings (tracks) and artist credits
+        # Include 'artist-credits' for album artist, 'media' for track count, 'recordings' for track details
+        release_details = musicbrainzngs.get_release_by_id(release_id, includes=["artist-credits", "media", "recordings", "release-groups"])
+
+        # --- Update ID3 Tags ---
+        audio_id3 = ID3(file_path) # Load with full ID3 object for more complex tags
+
+        # Album Artist (TPE2)
+        if release_details['release']['artist-credit']:
+            album_artist_name = release_details['release']['artist-credit-string']
+            audio_id3.delall('TPE2') # Remove existing album artist
+            audio_id3.add(TPE2(encoding=3, text=album_artist_name))
+            log_entries_list.append(f"Set Album Artist to: {album_artist_name}")
+            # Also update EasyID3 view if possible, though 'albumartist' is standard
+            try:
+                easy_audio = EasyID3(file_path)
+                easy_audio['albumartist'] = album_artist_name
+                easy_audio.save()
+            except Exception as e:
+                log_entries_list.append(f"Note: Could not set 'albumartist' via EasyID3: {e}")
+
+
+        # Track Number / Total Tracks (TRCK)
+        # This requires matching the specific file to a track in the release
+        # For simplicity, if it's a single file, we won't try to match it to a specific track number from album
+        # If the release has media and tracks:
+        if release_details['release']['medium-list'] and release_details['release']['medium-list'][0]['track-list']:
+            total_tracks = str(release_details['release']['medium-list'][0]['track-count'])
+            # Attempt to find the current track's title in the release to get its number
+            # This is a simplified matching logic.
+            current_track_title = audio.get('title', [None])[0]
+            track_number_str = ""
+
+            if current_track_title:
+                for track_info in release_details['release']['medium-list'][0]['track-list']:
+                    if track_info['recording']['title'].lower() == current_track_title.lower():
+                        track_number_str = str(track_info['number'])
+                        break
+
+            if track_number_str:
+                track_tag_text = f"{track_number_str}/{total_tracks}"
+            else: # Fallback if specific track not matched or no title
+                track_tag_text = f"1/{total_tracks}" # Default to 1 if not found or single file
+
+            audio_id3.delall('TRCK')
+            audio_id3.add(TRCK(encoding=3, text=track_tag_text))
+            log_entries_list.append(f"Set Track Number/Total to: {track_tag_text}")
+
+        # Year (TYER / TDRC in ID3 v2.4)
+        # EasyID3 uses 'date' which maps to TDRC or TYER depending on version/format.
+        # MusicBrainz provides 'date' like "YYYY-MM-DD" or "YYYY".
+        if release_details['release'].get('date'):
+            year = release_details['release']['date'].split('-')[0]
+            audio['date'] = year # Using EasyID3 for simplicity here
+            audio.save() # Save EasyID3 changes
+            # For ID3 object directly:
+            # audio_id3.delall('TYER')
+            # audio_id3.add(TYER(encoding=3, text=year))
+            log_entries_list.append(f"Set Year to: {year}")
+
+        # Cover Art (APIC)
+        try:
+            # Get cover art from Cover Art Archive
+            art_info = musicbrainzngs.get_release_group_image_list(release['release-group']['id'])
+            if art_info and art_info['images']:
+                # Prioritize front cover
+                front_cover_url = None
+                for img in art_info['images']:
+                    if 'Front' in img['types'] and img.get('approved'):
+                        front_cover_url = img['thumbnails']['large'] # or 'image' for full size
+                        break
+                if not front_cover_url and art_info['images'][0].get('approved'): # Fallback to first approved image
+                     front_cover_url = art_info['images'][0]['thumbnails']['large']
+
+                if front_cover_url:
+                    log_entries_list.append(f"Fetching cover art from: {front_cover_url}")
+                    response = requests.get(front_cover_url, timeout=10)
+                    response.raise_for_status() # Raise an exception for bad status codes
+
+                    # Determine mime type from URL or response headers if necessary
+                    mime_type = 'image/jpeg' # Default, CAA usually provides JPEG
+                    if '.png' in front_cover_url:
+                        mime_type = 'image/png'
+
+                    audio_id3.delall('APIC')
+                    audio_id3.add(APIC(
+                        encoding=3, # UTF-8
+                        mime=mime_type,
+                        type=3, # Cover (front)
+                        desc='Cover',
+                        data=response.content
+                    ))
+                    log_entries_list.append(f"Successfully embedded cover art from {front_cover_url}")
+                else:
+                    log_entries_list.append("No approved front cover art found on MusicBrainz.")
+            else:
+                log_entries_list.append("No cover art found on MusicBrainz for this release group.")
+        except requests.exceptions.RequestException as e:
+            log_entries_list.append(f"Error fetching cover art: {e}")
+        except musicbrainzngs.WebServiceError as e:
+            log_entries_list.append(f"MusicBrainz error fetching cover art: {e}")
+        except Exception as e:
+            log_entries_list.append(f"An unexpected error occurred during cover art processing: {e}")
+
+        audio_id3.save(v2_version=3) # Save changes using ID3 object, ensure v2.3 for compatibility
+        log_entries_list.append(f"Successfully updated tags for {file_path} from MusicBrainz.")
+
+    except musicbrainzngs.WebServiceError as exc:
+        log_entries_list.append(f"MusicBrainz API error for {file_path}: {exc}")
+    except requests.exceptions.RequestException as exc:
+        log_entries_list.append(f"Network error for {file_path} (e.g., fetching cover art): {exc}")
+    except Exception as e:
+        log_entries_list.append(f"An unexpected error occurred while processing {file_path}: {e}")
+
+
 def main():
     """
     Parses command-line arguments and executes the requested operations.
@@ -486,6 +647,7 @@ Usage examples:
     parser.add_argument('-y', '--year', type=str, help='Year to set (e.g., "2023") for all .mp3 files.')
     parser.add_argument('--show', action='store_true', help='Display current ID3 tags of .mp3 files in a table format in the terminal.')
     parser.add_argument('--html', action='store_true', help='Generate an HTML file ("mp3_tags.html") displaying current ID3 tags.')
+    parser.add_argument('--fetch-metadata', action='store_true', help='Fetch metadata from MusicBrainz for .mp3 files in the folder.')
     parser.add_argument('-R', '--recursive', action='store_true', help='Recursively process .mp3 files in subdirectories. If not set, only files in the specified folder are processed.')
 
     # If no arguments are provided (other than the script name itself), print help and exit.
@@ -506,7 +668,8 @@ Usage examples:
         args.genre is not None,
         args.rating is not None,
         args.cover_art is not None,
-        args.year is not None
+        args.year is not None,
+        args.fetch_metadata
     ])
 
     # If no action or tag setting was specified (e.g., "python tag_album.py --folder /some/path"),
@@ -536,6 +699,28 @@ Usage examples:
         set_cover_art(folder, args.cover_art, args.recursive)
     if args.year:
         set_year_tag(folder, args.year, args.recursive)
+
+    if args.fetch_metadata:
+        log_entries = []
+        files_processed_count = 0
+        if args.recursive:
+            for root, _, files in os.walk(folder):
+                for file in files:
+                    if file.lower().endswith('.mp3'):
+                        file_path = os.path.join(root, file)
+                        fetch_metadata_from_musicbrainz(file_path, log_entries)
+                        files_processed_count +=1
+        else:
+            for file in os.listdir(folder):
+                file_path = os.path.join(folder, file)
+                if os.path.isfile(file_path) and file.lower().endswith('.mp3'):
+                    fetch_metadata_from_musicbrainz(file_path, log_entries)
+                    files_processed_count += 1
+
+        if files_processed_count > 0:
+            write_log(log_entries, "metadata_fetching")
+        else:
+            print("No MP3 files found to fetch metadata for.")
 
 
 if __name__ == "__main__":

--- a/test/test_tag_album.py
+++ b/test/test_tag_album.py
@@ -11,6 +11,13 @@ from mutagen.id3 import ID3, ID3NoHeaderError # Added ID3NoHeaderError here
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 import tag_album 
 
+# Imports for mocking
+from unittest.mock import patch, MagicMock, call # Added call for checking mock calls
+
+# Modules to be mocked that are used by tag_album.py
+import musicbrainzngs
+import requests
+
 class TestTagAlbum(unittest.TestCase):
     def setUp(self):
         self.test_dir = "temp_test_mp3s"
@@ -337,6 +344,387 @@ class TestTagAlbum(unittest.TestCase):
         # self.assertIn(f"<td>{os.path.basename(self.test_mp3_path)}</td>", html_content, f"The filename '{os.path.basename(self.test_mp3_path)}' in a <td> tag is missing from HTML output.")
 
         # Cleanup of mp3_tags.html is handled by tearDown method
+
+    # --- Tests for fetch_metadata_from_musicbrainz ---
+
+    @patch('tag_album.requests.get')
+    @patch('tag_album.musicbrainzngs.get_release_group_image_list')
+    @patch('tag_album.musicbrainzngs.get_release_by_id')
+    @patch('tag_album.musicbrainzngs.search_releases')
+    @patch('tag_album.musicbrainzngs.set_useragent')
+    def test_fetch_metadata_success(self, mock_set_useragent, mock_search_releases, mock_get_release_by_id, mock_get_release_group_image_list, mock_requests_get):
+        # --- Setup Test MP3 ---
+        try:
+            audio = EasyID3(self.test_mp3_path)
+        except ID3NoHeaderError:
+            # If no ID3 header, create one for the test
+            id3 = ID3()
+            id3.save(self.test_mp3_path)
+            audio = EasyID3(self.test_mp3_path) # Reload
+
+        initial_artist = "Initial Artist"
+        initial_album = "Initial Album"
+        initial_title = "Initial Title"
+        audio['artist'] = initial_artist
+        audio['album'] = initial_album
+        audio['title'] = initial_title # Important for track matching
+        audio.save()
+
+        # --- Configure Mocks ---
+        # musicbrainzngs.set_useragent: No return value to check, just that it's called.
+
+        # musicbrainzngs.search_releases
+        mock_search_releases.return_value = {
+            'release-list': [{
+                'id': 'release-id-123',
+                'title': 'Fetched Album Title',
+                'ext:score': '100',
+                'artist-credit-string': 'Fetched Artist', # Used for logging
+                'release-group': {'id': 'release-group-id-456'}
+            }]
+        }
+
+        # musicbrainzngs.get_release_by_id
+        mock_get_release_by_id.return_value = {
+            'release': {
+                'id': 'release-id-123',
+                'title': 'Fetched Album Title',
+                'artist-credit-string': 'Fetched Album Artist', # This is TPE2
+                'artist-credit': [{'artist': {'name': 'Fetched Album Artist'}}], # More detailed structure
+                'date': '2023-10-26',
+                'medium-list': [{
+                    'track-count': 2,
+                    'track-list': [
+                        {'number': '1', 'recording': {'title': 'Another Title'}, 'length': '180000'},
+                        {'number': '2', 'recording': {'title': initial_title}, 'length': '200000'} # Match this title
+                    ]
+                }],
+                'release-group': {'id': 'release-group-id-456'} # Needed for cover art call
+            }
+        }
+
+        # musicbrainzngs.get_release_group_image_list (for cover art)
+        mock_get_release_group_image_list.return_value = {
+            'images': [{
+                'types': ['Front'],
+                'approved': True,
+                'thumbnails': {'large': 'http://example.com/cover.jpg'}
+            }]
+        }
+
+        # requests.get (for fetching cover image)
+        mock_cover_response = MagicMock()
+        mock_cover_response.content = b'dummy jpeg data'
+        mock_cover_response.raise_for_status = MagicMock() # Does nothing if called
+        mock_requests_get.return_value = mock_cover_response
+
+        # --- Call the function under test ---
+        log_entries = []
+        tag_album.fetch_metadata_from_musicbrainz(self.test_mp3_path, log_entries)
+
+        # --- Assertions ---
+        mock_set_useragent.assert_called_once_with("tag-album-script", "0.1", "http://example.com/tag-album-script")
+        mock_search_releases.assert_called_once_with(artist=initial_artist, release=initial_album, limit=5)
+        mock_get_release_by_id.assert_called_once_with('release-id-123', includes=["artist-credits", "media", "recordings", "release-groups"])
+        mock_get_release_group_image_list.assert_called_once_with('release-group-id-456')
+        mock_requests_get.assert_called_once_with('http://example.com/cover.jpg', timeout=10)
+        mock_cover_response.raise_for_status.assert_called_once()
+
+        # Check ID3 tags
+        audio_tags = ID3(self.test_mp3_path)
+        self.assertEqual(audio_tags['TPE2'].text[0], 'Fetched Album Artist')
+        self.assertEqual(audio_tags['TRCK'].text[0], '2/2') # Matched 'Initial Title' as track 2
+        self.assertEqual(audio_tags['APIC:Cover'].data, b'dummy jpeg data')
+
+        # EasyID3 for date/year
+        easy_audio_tags = EasyID3(self.test_mp3_path)
+        self.assertEqual(easy_audio_tags['date'][0], '2023')
+        self.assertEqual(easy_audio_tags['albumartist'][0], 'Fetched Album Artist') # Check if EasyID3 also got it
+
+        # Check log messages (optional, but good for confirming behavior)
+        self.assertIn(f"Processing {self.test_mp3_path}: Artist='{initial_artist}', Album='{initial_album}'", log_entries)
+        self.assertIn("Found release: Fetched Album Title (release-id-123) with score 100%", log_entries) # Note: release title from search, not get_release_by_id
+        self.assertIn("Set Album Artist to: Fetched Album Artist", log_entries)
+        self.assertIn("Set Track Number/Total to: 2/2", log_entries)
+        self.assertIn("Set Year to: 2023", log_entries)
+        self.assertIn("Fetching cover art from: http://example.com/cover.jpg", log_entries)
+        self.assertIn("Successfully embedded cover art from http://example.com/cover.jpg", log_entries)
+        self.assertIn(f"Successfully updated tags for {self.test_mp3_path} from MusicBrainz.", log_entries)
+
+    @patch('tag_album.musicbrainzngs.search_releases')
+    @patch('tag_album.musicbrainzngs.set_useragent')
+    def test_fetch_metadata_no_release_found(self, mock_set_useragent, mock_search_releases):
+        # --- Setup Test MP3 ---
+        try:
+            audio = EasyID3(self.test_mp3_path)
+        except ID3NoHeaderError:
+            ID3().save(self.test_mp3_path)
+            audio = EasyID3(self.test_mp3_path)
+
+        initial_artist = "ArtistNoRelease"
+        initial_album = "AlbumNoRelease"
+        audio['artist'] = initial_artist
+        audio['album'] = initial_album
+        audio['title'] = "Some Title" # Needs a title for full initial state
+        audio.save()
+        # Store initial tags to compare later
+        initial_tags = audio.copy()
+
+
+        # --- Configure Mocks ---
+        mock_search_releases.return_value = {'release-list': []} # No releases found
+
+        # --- Call the function under test ---
+        log_entries = []
+        tag_album.fetch_metadata_from_musicbrainz(self.test_mp3_path, log_entries)
+
+        # --- Assertions ---
+        mock_set_useragent.assert_called_once()
+        mock_search_releases.assert_called_once_with(artist=initial_artist, release=initial_album, limit=5)
+
+        # Check that tags were NOT changed
+        current_tags = EasyID3(self.test_mp3_path)
+        self.assertEqual(current_tags.get('artist', [None])[0], initial_artist)
+        self.assertEqual(current_tags.get('album', [None])[0], initial_album)
+        self.assertEqual(current_tags.get('title', [None])[0], "Some Title")
+
+        # Check that other complex tags like TPE2, TRCK, APIC were not added
+        id3_tags = ID3(self.test_mp3_path)
+        self.assertNotIn('TPE2', id3_tags)
+        self.assertNotIn('TRCK', id3_tags)
+        self.assertNotIn('APIC:', id3_tags) # Check for any APIC frame
+
+        # Check log messages
+        self.assertIn(f"Processing {self.test_mp3_path}: Artist='{initial_artist}', Album='{initial_album}'", log_entries)
+        self.assertIn(f"No results found on MusicBrainz for {initial_artist} - {initial_album} in {self.test_mp3_path}.", log_entries)
+        self.assertNotIn(f"Successfully updated tags for {self.test_mp3_path} from MusicBrainz.", log_entries)
+
+    @patch('tag_album.requests.get') # Still need to patch requests.get as it's in the import list of tag_album
+    @patch('tag_album.musicbrainzngs.get_release_group_image_list')
+    @patch('tag_album.musicbrainzngs.get_release_by_id')
+    @patch('tag_album.musicbrainzngs.search_releases')
+    @patch('tag_album.musicbrainzngs.set_useragent')
+    def test_fetch_metadata_release_found_no_cover_art(self, mock_set_useragent, mock_search_releases, mock_get_release_by_id, mock_get_release_group_image_list, mock_requests_get):
+        # --- Setup Test MP3 ---
+        try:
+            audio = EasyID3(self.test_mp3_path)
+        except ID3NoHeaderError:
+            ID3().save(self.test_mp3_path)
+            audio = EasyID3(self.test_mp3_path)
+
+        initial_artist = "ArtistNoCover"
+        initial_album = "AlbumNoCover"
+        initial_title = "TitleNoCover"
+        audio['artist'] = initial_artist
+        audio['album'] = initial_album
+        audio['title'] = initial_title
+        audio.save()
+
+        # --- Configure Mocks ---
+        mock_search_releases.return_value = {
+            'release-list': [{'id': 'release-id-nocover', 'title': 'Album Title No Cover', 'ext:score': '95', 'release-group': {'id': 'rg-id-nocover'}}]
+        }
+        mock_get_release_by_id.return_value = {
+            'release': {
+                'id': 'release-id-nocover', 'title': 'Album Title No Cover', 'artist-credit-string': 'Artist Name NoCover',
+                'date': '2022', 'medium-list': [{'track-count': 1, 'track-list': [{'number': '1', 'recording': {'title': initial_title}}]}],
+                'release-group': {'id': 'rg-id-nocover'}
+            }
+        }
+        mock_get_release_group_image_list.return_value = {'images': []} # No images
+
+        # --- Call the function under test ---
+        log_entries = []
+        tag_album.fetch_metadata_from_musicbrainz(self.test_mp3_path, log_entries)
+
+        # --- Assertions ---
+        mock_set_useragent.assert_called_once()
+        mock_search_releases.assert_called_once_with(artist=initial_artist, release=initial_album, limit=5)
+        mock_get_release_by_id.assert_called_once_with('release-id-nocover', includes=["artist-credits", "media", "recordings", "release-groups"])
+        mock_get_release_group_image_list.assert_called_once_with('rg-id-nocover')
+        mock_requests_get.assert_not_called() # IMPORTANT: requests.get should not be called if no image URL
+
+        # Check ID3 tags (other tags should be updated)
+        audio_tags = ID3(self.test_mp3_path)
+        self.assertEqual(audio_tags['TPE2'].text[0], 'Artist Name NoCover')
+        self.assertEqual(audio_tags['TRCK'].text[0], '1/1')
+        self.assertNotIn('APIC:Cover', audio_tags) # No cover art tag
+
+        easy_audio_tags = EasyID3(self.test_mp3_path)
+        self.assertEqual(easy_audio_tags['date'][0], '2022')
+        self.assertEqual(easy_audio_tags['albumartist'][0], 'Artist Name NoCover')
+
+
+        # Check log messages
+        self.assertIn(f"Processing {self.test_mp3_path}: Artist='{initial_artist}', Album='{initial_album}'", log_entries)
+        self.assertIn("Found release: Album Title No Cover (release-id-nocover) with score 95%", log_entries)
+        self.assertIn("Set Album Artist to: Artist Name NoCover", log_entries)
+        self.assertIn("Set Track Number/Total to: 1/1", log_entries)
+        self.assertIn("Set Year to: 2022", log_entries)
+        self.assertIn("No cover art found on MusicBrainz for this release group.", log_entries)
+        self.assertNotIn("Fetching cover art from:", "\n".join(log_entries)) # Ensure no attempt to fetch
+        self.assertIn(f"Successfully updated tags for {self.test_mp3_path} from MusicBrainz.", log_entries)
+
+    @patch('tag_album.musicbrainzngs.search_releases')
+    @patch('tag_album.musicbrainzngs.set_useragent')
+    def test_fetch_metadata_api_error_search(self, mock_set_useragent, mock_search_releases):
+        # --- Setup Test MP3 ---
+        try:
+            audio = EasyID3(self.test_mp3_path)
+        except ID3NoHeaderError:
+            ID3().save(self.test_mp3_path)
+            audio = EasyID3(self.test_mp3_path)
+        initial_artist = "ArtistApiError"
+        initial_album = "AlbumApiError"
+        audio['artist'] = initial_artist
+        audio['album'] = initial_album
+        audio.save()
+        initial_tags_check = audio.copy() # To verify no tags changed
+
+        # --- Configure Mocks ---
+        mock_search_releases.side_effect = musicbrainzngs.WebServiceError("API search failed")
+
+        # --- Call the function under test ---
+        log_entries = []
+        tag_album.fetch_metadata_from_musicbrainz(self.test_mp3_path, log_entries)
+
+        # --- Assertions ---
+        mock_set_useragent.assert_called_once()
+        mock_search_releases.assert_called_once_with(artist=initial_artist, release=initial_album, limit=5)
+
+        # Check that tags were NOT changed
+        current_tags = EasyID3(self.test_mp3_path)
+        self.assertEqual(dict(current_tags), dict(initial_tags_check))
+
+        # Check log messages
+        self.assertIn(f"Processing {self.test_mp3_path}: Artist='{initial_artist}', Album='{initial_album}'", log_entries)
+        self.assertIn(f"MusicBrainz API error for {self.test_mp3_path}: API search failed", log_entries)
+        self.assertNotIn(f"Successfully updated tags for {self.test_mp3_path} from MusicBrainz.", log_entries)
+
+    @patch('tag_album.requests.get')
+    @patch('tag_album.musicbrainzngs.get_release_group_image_list')
+    @patch('tag_album.musicbrainzngs.get_release_by_id')
+    @patch('tag_album.musicbrainzngs.search_releases')
+    @patch('tag_album.musicbrainzngs.set_useragent')
+    def test_fetch_metadata_network_error_cover(self, mock_set_useragent, mock_search_releases, mock_get_release_by_id, mock_get_release_group_image_list, mock_requests_get):
+        # --- Setup Test MP3 ---
+        try:
+            audio = EasyID3(self.test_mp3_path)
+        except ID3NoHeaderError:
+            ID3().save(self.test_mp3_path)
+            audio = EasyID3(self.test_mp3_path)
+
+        initial_artist = "ArtistNetError"
+        initial_album = "AlbumNetError"
+        initial_title = "TitleNetError"
+        audio['artist'] = initial_artist
+        audio['album'] = initial_album
+        audio['title'] = initial_title
+        audio.save()
+
+        # --- Configure Mocks (similar to success, but requests.get fails) ---
+        mock_search_releases.return_value = {
+            'release-list': [{'id': 'release-id-neterr', 'title': 'Album Title NetErr', 'ext:score': '90', 'release-group': {'id': 'rg-id-neterr'}}]
+        }
+        mock_get_release_by_id.return_value = {
+            'release': {
+                'id': 'release-id-neterr', 'title': 'Album Title NetErr', 'artist-credit-string': 'Artist Name NetErr',
+                'date': '2021', 'medium-list': [{'track-count': 1, 'track-list': [{'number': '1', 'recording': {'title': initial_title}}]}],
+                'release-group': {'id': 'rg-id-neterr'}
+            }
+        }
+        mock_get_release_group_image_list.return_value = { # Found a cover
+            'images': [{'types': ['Front'], 'approved': True, 'thumbnails': {'large': 'http://example.com/cover-neterr.jpg'}}]
+        }
+        mock_requests_get.side_effect = requests.exceptions.RequestException("Network failed for cover")
+
+        # --- Call the function under test ---
+        log_entries = []
+        tag_album.fetch_metadata_from_musicbrainz(self.test_mp3_path, log_entries)
+
+        # --- Assertions ---
+        mock_set_useragent.assert_called_once()
+        mock_search_releases.assert_called_once_with(artist=initial_artist, release=initial_album, limit=5)
+        mock_get_release_by_id.assert_called_once_with('release-id-neterr', includes=["artist-credits", "media", "recordings", "release-groups"])
+        mock_get_release_group_image_list.assert_called_once_with('rg-id-neterr')
+        mock_requests_get.assert_called_once_with('http://example.com/cover-neterr.jpg', timeout=10)
+
+        # Check ID3 tags (other tags SHOULD be updated, cover art fails)
+        audio_tags = ID3(self.test_mp3_path)
+        self.assertEqual(audio_tags['TPE2'].text[0], 'Artist Name NetErr')
+        self.assertEqual(audio_tags['TRCK'].text[0], '1/1')
+        self.assertNotIn('APIC:Cover', audio_tags) # No cover art tag due to network error
+
+        easy_audio_tags = EasyID3(self.test_mp3_path)
+        self.assertEqual(easy_audio_tags['date'][0], '2021')
+        self.assertEqual(easy_audio_tags['albumartist'][0], 'Artist Name NetErr')
+
+        # Check log messages
+        self.assertIn(f"Processing {self.test_mp3_path}: Artist='{initial_artist}', Album='{initial_album}'", log_entries)
+        self.assertIn("Found release: Album Title NetErr (release-id-neterr) with score 90%", log_entries)
+        self.assertIn("Set Album Artist to: Artist Name NetErr", log_entries)
+        self.assertIn("Error fetching cover art: Network failed for cover", log_entries)
+        # This success message should still appear as other tags were set
+        self.assertIn(f"Successfully updated tags for {self.test_mp3_path} from MusicBrainz.", log_entries)
+
+    @patch('tag_album.musicbrainzngs.set_useragent') # To prevent actual calls
+    def test_fetch_metadata_missing_initial_artist_album_tags(self, mock_set_useragent):
+        # --- Setup Test MP3 (ensure it has no artist/album) ---
+        try:
+            audio = EasyID3(self.test_mp3_path)
+            if 'artist' in audio: del audio['artist']
+            if 'album' in audio: del audio['album']
+            audio['title'] = "Title Only" # Keep some other tag
+            audio.save()
+        except ID3NoHeaderError: # If no header, create one, but without artist/album
+            id3 = ID3()
+            id3.save(self.test_mp3_path)
+            audio = EasyID3(self.test_mp3_path)
+            audio['title'] = "Title Only"
+            audio.save()
+
+        initial_tags_check = EasyID3(self.test_mp3_path).copy()
+
+        # --- Call the function under test ---
+        log_entries = []
+        tag_album.fetch_metadata_from_musicbrainz(self.test_mp3_path, log_entries)
+
+        # --- Assertions ---
+        mock_set_useragent.assert_not_called() # Should exit before setting useragent
+
+        # Check that tags were NOT changed
+        current_tags = EasyID3(self.test_mp3_path)
+        self.assertEqual(dict(current_tags), dict(initial_tags_check))
+
+        # Check log messages
+        self.assertIn(f"Skipping {self.test_mp3_path}: Artist or Album tag not found.", log_entries)
+        self.assertNotIn(f"Processing {self.test_mp3_path}", "\n".join(log_entries)) # Should not start processing
+        self.assertNotIn(f"Successfully updated tags for {self.test_mp3_path} from MusicBrainz.", log_entries)
+
+    @patch('tag_album.EasyID3') # Mock EasyID3 specifically for this test at the module level
+    @patch('tag_album.musicbrainzngs.set_useragent')
+    def test_fetch_metadata_id3_no_header_error_initial_read(self, mock_set_useragent, mock_easy_id3_constructor):
+        # --- Setup Test MP3 (file content doesn't matter as EasyID3 is mocked) ---
+        # We don't need to set actual tags on self.test_mp3_path as EasyID3 call is mocked
+
+        # --- Configure Mocks ---
+        # Make the EasyID3 constructor raise ID3NoHeaderError when called inside the function
+        mock_easy_id3_constructor.side_effect = ID3NoHeaderError("Simulated no header error")
+
+        # --- Call the function under test ---
+        log_entries = []
+        # Pass a file path, it won't be used by the mocked EasyID3 in a way that reads the file here
+        tag_album.fetch_metadata_from_musicbrainz(self.test_mp3_path, log_entries)
+
+        # --- Assertions ---
+        mock_easy_id3_constructor.assert_called_once_with(self.test_mp3_path)
+        mock_set_useragent.assert_not_called() # Should exit before this
+
+        # Check log messages
+        self.assertIn(f"Skipping {self.test_mp3_path}: No ID3 header found to read artist/album.", log_entries)
+        self.assertNotIn(f"Processing {self.test_mp3_path}", "\n".join(log_entries))
+        self.assertNotIn(f"Successfully updated tags for {self.test_mp3_path} from MusicBrainz.", log_entries)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Add automatic metadata fetching from MusicBrainz

This feature allows users to query the MusicBrainz database to fetch and update missing metadata for their MP3 files.

Key changes:
- Added `musicbrainzngs` to project dependencies.
- Implemented `fetch_metadata_from_musicbrainz` function in `tag_album.py`:
    - Extracts existing artist and album tags.
    - Queries MusicBrainz API for release information.
    - Updates ID3 tags: album artist, track number/total, year, and cover art.
    - Handles errors and logs operations.
- Added a new command-line argument `--fetch-metadata` to trigger this functionality.
- Included comprehensive unit tests for various scenarios, including successful metadata retrieval, missing data, and API/network errors.
- Updated `README.md` with documentation for the new feature.

Output:
I've added a feature for automatic metadata fetching from MusicBrainz.

This will allow you to query the MusicBrainz database to fetch and update missing metadata for your MP3 files.

Here's a summary of what I did:
- I added `musicbrainzngs` to your project dependencies.
- I implemented a `fetch_metadata_from_musicbrainz` function in `tag_album.py`. This function:
    - Extracts existing artist and album tags.
    - Queries the MusicBrainz API for release information.
    - Updates ID3 tags: album artist, track number/total, year, and cover art.
    - Handles errors and logs operations.
- I added a new command-line argument `--fetch-metadata` to trigger this functionality.
- I included comprehensive unit tests for various scenarios, including successful metadata retrieval, missing data, and API/network errors.
- I updated your `README.md` with documentation for the new feature.