### PR TITLE
feat: Add AcoustID integration for tag fetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ You can use `tag_album.py` to update the album and artist tags of all MP3 files 
 | `--show`         | Displays the current metadata of the MP3 files                   |
 | `--html`         | Outputs the metadata in HTML format                              |
 | `--fetch-metadata` | Fetches metadata (album artist, track numbers, year, cover art) from MusicBrainz for MP3 files. Uses existing artist and album tags to search. |
+| `--fetch-and-set-acoustid-tags` | Fetches metadata from AcoustID (fingerprinting local files), and sets tags specified by `--fields`. Requires `fpcalc` to be installed. |
+| `--fields`                      | Comma-separated list of tags to fetch and set from AcoustID (e.g., "title,artist,album,genre"). Used with `--fetch-and-set-acoustid-tags`. |
 | `-R`, `--recursive` | Recursively process files in subdirectories. If not set, only files in the specified folder (non-recursive) are processed. |
 | `-h`, `--help`   | Shows the help message and exits.                                |
 
@@ -61,6 +63,10 @@ You can use `tag_album.py` to update the album and artist tags of all MP3 files 
   ```sh
   python tag_album.py -f /path/to/your/music --fetch-metadata -R
   ```
+- **Fetch and set tags (title, artist, album) from AcoustID for all MP3s in a folder:**
+  ```sh
+  python tag_album.py -f /path/to/your/music --fetch-and-set-acoustid-tags --fields "title,artist,album"
+  ```
 - **Show the help message:**
   ```sh
   python3 tag_album.py --help
@@ -89,6 +95,7 @@ To set up a virtual environment and install the required packages for `tag_album
     ```sh
     pip install -r requirements.txt
     ```
+    Note: The `--fetch-and-set-acoustid-tags` feature also requires the `fpcalc` command-line tool. You can typically install it as part of `libchromaprint-tools` (e.g., `sudo apt-get install libchromaprint-tools` on Debian/Ubuntu, or `brew install chromaprint` on macOS).
 
 Make sure you have a `requirements.txt` file in the same directory as `tag_album.py` with all the necessary dependencies listed.
 

--- a/tag_album.py
+++ b/tag_album.py
@@ -19,6 +19,7 @@ from tag_album_utils.display import show_folder_tags_in_pretty_HTML, show_folder
 from tag_album_utils.set_tags import set_artist_tag, set_album_tag, set_genre_tag, set_rating_tag, set_cover_art, set_year_tag
 from tag_album_utils.fetch_metadata import fetch_metadata_from_musicbrainz
 from tag_album_utils.utils import write_log
+from tag_album_utils.fetch_metadata import fetch_metadata_from_acoustid
 
 def main():
     """
@@ -50,6 +51,8 @@ Usage examples:
     parser.add_argument('--show', action='store_true', help='Display current ID3 tags of .mp3 files in a table format in the terminal.')
     parser.add_argument('--html', action='store_true', help='Generate an HTML file ("mp3_tags.html") displaying current ID3 tags.')
     parser.add_argument('--fetch-metadata', action='store_true', help='Fetch metadata from MusicBrainz for .mp3 files in the folder.')
+    parser.add_argument('--fetch-and-set-acoustid-tags', action='store_true', help='Fetch tags from AcoustID and set them.')
+    parser.add_argument('--fields', type=str, help='Comma-separated list of fields to fetch from AcoustID (e.g., "title,artist,album,genre"). Required if --fetch-and-set-acoustid-tags is used.')
     parser.add_argument('-R', '--recursive', action='store_true', help='Recursively process .mp3 files in subdirectories. If not set, only files in the specified folder are processed.')
 
     if len(sys.argv) == 1:
@@ -67,11 +70,16 @@ Usage examples:
         args.rating is not None,
         args.cover_art is not None,
         args.year is not None,
-        args.fetch_metadata
+        args.fetch_metadata,
+        args.fetch_and_set_acoustid_tags
     ])
 
     if not action_or_tag_specified:
         parser.print_help(sys.stderr)
+        sys.exit(1)
+
+    if args.fetch_and_set_acoustid_tags and not args.fields:
+        print("Error: --fields is required when --fetch-and-set-acoustid-tags is used.")
         sys.exit(1)
 
     folder = os.path.abspath(os.path.normpath(args.folder))
@@ -119,6 +127,43 @@ Usage examples:
             write_log(log_entries, "metadata_fetching") # write_log is imported
         else:
             print("No MP3 files found to fetch metadata for.")
+
+    if args.fetch_and_set_acoustid_tags:
+        log_entries = []
+        files_processed_count = 0
+        acoustid_api_key = "MDCUvH3Ppp"
+        requested_fields_list = [field.strip() for field in args.fields.split(',')]
+
+        if args.recursive:
+            for root, _, files in os.walk(folder):
+                for file_name in files:
+                    if file_name.lower().endswith('.mp3'):
+                        file_path = os.path.join(root, file_name)
+                        status = fetch_metadata_from_acoustid(file_path, acoustid_api_key, requested_fields_list, log_entries)
+                        if status == "FPCLAC_NOT_FOUND":
+                            print(f"Error: The 'fpcalc' utility is required for AcoustID tagging but was not found or is not executable. Please install libchromaprint-tools (or equivalent for your OS) and ensure 'fpcalc' is in your system's PATH.", file=sys.stderr)
+                            print("Aborting AcoustID tagging.", file=sys.stderr)
+                            sys.exit(1)
+                        # elif status == "FPCLAC_ERROR":
+                        #     print(f"Error: Failed to execute 'fpcalc' for file: {file_path}. See log for details.", file=sys.stderr)
+                        files_processed_count += 1
+        else:
+            for file_name in os.listdir(folder):
+                file_path = os.path.join(folder, file_name)
+                if os.path.isfile(file_path) and file_name.lower().endswith('.mp3'):
+                    status = fetch_metadata_from_acoustid(file_path, acoustid_api_key, requested_fields_list, log_entries)
+                    if status == "FPCLAC_NOT_FOUND":
+                        print(f"Error: The 'fpcalc' utility is required for AcoustID tagging but was not found or is not executable. Please install libchromaprint-tools (or equivalent for your OS) and ensure 'fpcalc' is in your system's PATH.", file=sys.stderr)
+                        print("Aborting AcoustID tagging.", file=sys.stderr)
+                        sys.exit(1)
+                    # elif status == "FPCLAC_ERROR":
+                    #     print(f"Error: Failed to execute 'fpcalc' for file: {file_path}. See log for details.", file=sys.stderr)
+                    files_processed_count += 1
+
+        if files_processed_count > 0:
+            write_log(log_entries, "acoustid_fetching")
+        else:
+            print("No MP3 files found for AcoustID processing.")
 
 
 if __name__ == "__main__":

--- a/tag_album.py
+++ b/tag_album.py
@@ -131,7 +131,7 @@ Usage examples:
     if args.fetch_and_set_acoustid_tags:
         log_entries = []
         files_processed_count = 0
-        acoustid_api_key = "MDCUvH3Ppp"
+        acoustid_api_key = "YiHCtGqK2I"
         requested_fields_list = [field.strip() for field in args.fields.split(',')]
 
         if args.recursive:

--- a/tag_album_utils/fetch_metadata.py
+++ b/tag_album_utils/fetch_metadata.py
@@ -142,3 +142,206 @@ def fetch_metadata_from_musicbrainz(file_path, log_entries_list):
         log_entries_list.append(f"Network error for {file_path} (e.g., fetching cover art): {exc}")
     except Exception as e:
         log_entries_list.append(f"An unexpected error occurred while processing {file_path}: {e}")
+
+
+import subprocess
+import json
+import os
+# requests is already imported
+# from mutagen.easyid3 import EasyID3 # Already imported
+# from mutagen.id3 import ID3NoHeaderError # Already imported
+from .set_tags import set_artist_tag, set_album_tag, set_genre_tag, set_title_tag # To be implemented in next step
+
+def fetch_metadata_from_acoustid(file_path, api_key, requested_fields, log_entries_list):
+    """
+    Fetches metadata from AcoustID for a given MP3 file and updates its ID3 tags.
+
+    Args:
+        file_path (str): The path to the MP3 file.
+        api_key (str): The AcoustID API key.
+        requested_fields (list): A list of strings indicating which tags to fetch and set.
+        log_entries_list (list): A list to append log messages to.
+    """
+    fpcalc_path = "fpcalc"
+    file_name = os.path.basename(file_path)
+
+    # 1. Check for fpcalc
+    try:
+        fpcalc_check = subprocess.run([fpcalc_path, "-version"], capture_output=True, text=True, check=False, timeout=5)
+        if fpcalc_check.returncode != 0:
+            log_entries_list.append(f"CRITICAL: fpcalc not found or not executable at '{fpcalc_path}'. Please ensure it is installed and in your PATH. Exit code {fpcalc_check.returncode}. Stderr: {fpcalc_check.stderr.strip()}")
+            return "FPCLAC_NOT_FOUND"
+    except FileNotFoundError:
+        log_entries_list.append(f"CRITICAL: fpcalc command not found at '{fpcalc_path}'. Please ensure it is installed and in your PATH.")
+        return "FPCLAC_NOT_FOUND"
+    except subprocess.TimeoutExpired:
+        log_entries_list.append(f"CRITICAL: fpcalc -version command timed out for '{fpcalc_path}'.")
+        return "FPCLAC_NOT_FOUND" # Or a different error like FPCLAC_TIMEOUT, but NOT_FOUND is actionable for user.
+    except Exception as e:
+        log_entries_list.append(f"CRITICAL: Failed to check fpcalc version for '{fpcalc_path}': {e}")
+        return "FPCLAC_NOT_FOUND" # Or a different error.
+
+    # 2. Execute fpcalc
+    try:
+        process = subprocess.run([fpcalc_path, "-json", file_path], capture_output=True, text=True, check=False, timeout=15) # check=False to handle error manually
+        if process.returncode != 0:
+            log_entries_list.append(f"Error for {file_name}: fpcalc execution failed with exit code {process.returncode}. Command: '{process.args}'. stderr: {process.stderr.strip()}")
+            return "FPCLAC_ERROR"
+        fpcalc_output = json.loads(process.stdout)
+        fingerprint = fpcalc_output.get("fingerprint")
+        duration = fpcalc_output.get("duration")
+
+        if not fingerprint or not duration:
+            log_entries_list.append(f"Error for {file_name}: Could not extract fingerprint or duration from fpcalc JSON output. Output: {process.stdout[:200]}")
+            return "FPCLAC_ERROR"
+        log_entries_list.append(f"Successfully obtained fingerprint and duration for {file_name}.")
+
+    # subprocess.CalledProcessError is not needed if check=False
+    except subprocess.TimeoutExpired:
+        log_entries_list.append(f"Error for {file_name}: fpcalc execution timed out for {file_path}.")
+        return "FPCLAC_ERROR"
+    except json.JSONDecodeError:
+        log_entries_list.append(f"Error for {file_name}: Could not decode JSON from fpcalc output. Output: {process.stdout[:200]}")
+        return "FPCLAC_ERROR"
+    except Exception as e:
+        log_entries_list.append(f"Error for {file_name}: An unexpected error occurred during fpcalc processing: {e}")
+        return "FPCLAC_ERROR"
+
+    # 3. Prepare for AcoustID API Call
+    acoustid_meta_sources = {
+        "title": "recordings",
+        "artist": "recordings", # "recordingids" also useful for artists if we want MBIDs
+        "album": "releasegroups", # "recordingids" also useful for album MBIDs via recordings
+        # "genre": "releasegroups" # Genre from releasegroups can be via tags, often user-submitted.
+                                 # Recordings can also have genres from MusicBrainz.
+    }
+    meta_param_parts = set(["compress"]) # "compress" is generally good to have.
+    for field in requested_fields:
+        source = acoustid_meta_sources.get(field)
+        if source:
+            meta_param_parts.add(source)
+
+    # Ensure essential sources if specific fields are requested
+    if "artist" in requested_fields : meta_param_parts.add("recordingids") # Needed for artist MBID
+    if "album" in requested_fields : meta_param_parts.add("recordingids") # Needed for album MBID via recordings->releasegroups
+    if "genre" in requested_fields: # Explicitly add sources that might contain genre
+        meta_param_parts.add("recordings") # For MB genres associated with recordings
+        meta_param_parts.add("releasegroups") # For user tags on release groups
+
+
+    if not meta_param_parts or meta_param_parts == {"compress"}: # If only "compress" is there, add defaults
+        meta_param = "recordings,releasegroups,compress"
+    else:
+        meta_param = ",".join(list(meta_param_parts))
+
+    log_entries_list.append(f"For {file_name}, using AcoustID meta: {meta_param}")
+
+
+    # 4. Call AcoustID API
+    api_url = "https://api.acoustid.org/v2/lookup"
+    params = {
+        "client": api_key,
+        "meta": meta_param,
+        "duration": str(int(duration)),
+        "fingerprint": fingerprint
+    }
+
+    try:
+        response = requests.get(api_url, params=params, timeout=10)
+        response.raise_for_status()
+        api_data = response.json()
+    except requests.exceptions.HTTPError as e:
+        log_entries_list.append(f"Error for {file_name}: AcoustID API request failed with HTTP status {e.response.status_code}: {e.response.text[:200]}")
+        return "SUCCESS" # Or specific API_ERROR, but problem was not fpcalc
+    except requests.exceptions.Timeout:
+        log_entries_list.append(f"Error for {file_name}: AcoustID API request timed out.")
+        return "SUCCESS" # Or specific API_ERROR
+    except requests.exceptions.RequestException as e:
+        log_entries_list.append(f"Error for {file_name}: AcoustID API request failed: {e}")
+        return "SUCCESS" # Or specific API_ERROR
+    except json.JSONDecodeError:
+        log_entries_list.append(f"Error for {file_name}: Could not decode JSON from AcoustID API response. Response: {response.text[:200]}")
+        return "SUCCESS" # Or specific API_ERROR
+
+    # 5. Process API Response
+    if api_data.get("status") == "ok" and api_data.get("results"):
+        results = api_data["results"]
+        results.sort(key=lambda x: x.get("score", 0), reverse=True)
+        best_result = results[0]
+        score = best_result.get("score", 0) * 100
+        log_entries_list.append(f"Found match for {file_name}: Score {score:.2f}%")
+
+        title_to_set = None
+        artist_to_set = None
+        album_to_set = None
+        genre_to_set = None
+
+        # Extract Tags
+        try:
+            if "title" in requested_fields and best_result.get("recordings"):
+                title_to_set = best_result["recordings"][0].get("title")
+                if not title_to_set: log_entries_list.append(f"Title not found in AcoustID response for {file_name}.")
+
+            if "artist" in requested_fields and best_result.get("recordings"):
+                if best_result["recordings"][0].get("artists"):
+                    artist_to_set = best_result["recordings"][0]["artists"][0].get("name")
+                    if not artist_to_set: log_entries_list.append(f"Artist name not found in AcoustID response for {file_name}.")
+                else:
+                    log_entries_list.append(f"Artist section not found in AcoustID recordings for {file_name}.")
+
+            if "album" in requested_fields:
+                # Album can be from recordings -> releasegroups
+                if best_result.get("recordings") and best_result["recordings"][0].get("releasegroups"):
+                    album_to_set = best_result["recordings"][0]["releasegroups"][0].get("title")
+                # Or directly from results -> releasegroups if that part of 'meta' was requested and fruitful
+                elif best_result.get("releasegroups"):
+                     album_to_set = best_result["releasegroups"][0].get("title")
+                if not album_to_set: log_entries_list.append(f"Album not found in AcoustID response for {file_name}.")
+
+            if "genre" in requested_fields:
+                # Try MusicBrainz genre from recordings first
+                if best_result.get("recordings") and best_result["recordings"][0].get("genres"):
+                    genre_to_set = best_result["recordings"][0]["genres"][0].get("name")
+                # Fallback to user tags on release groups (less reliable)
+                elif best_result.get("releasegroups") and best_result["releasegroups"][0].get("tags") and best_result["releasegroups"][0]["tags"].get("genre"):
+                     genre_to_set = best_result["releasegroups"][0]["tags"]["genre"][0] # take first genre tag
+                if not genre_to_set: log_entries_list.append(f"Genre not found or could not be determined from AcoustID response for {file_name}.")
+
+        except (KeyError, IndexError) as e:
+            log_entries_list.append(f"Error for {file_name}: Issue extracting tag from AcoustID response structure: {e}. Response snippet: {str(best_result)[:200]}")
+        except Exception as e: # Catch any other unexpected error during extraction
+            log_entries_list.append(f"Unexpected error extracting tags for {file_name}: {e}")
+
+
+        # 6. Set Tags using Mutagen (assuming adapted setters)
+        # Note: The set_..._tag functions are assumed to be adapted to take (file_path, value, False, log_entries_list)
+        # and that 'False' means 'not recursive' (as they operate on a single file here).
+        # This adaptation is part of the next subtask.
+
+        # Check if audio file can be loaded (basic check before trying to set tags)
+        try:
+            EasyID3(file_path) # Try to load, ID3NoHeaderError is fine for setting new tags
+        except ID3NoHeaderError:
+            log_entries_list.append(f"Info for {file_name}: No ID3 header, tags will be created.")
+        except Exception as e:
+            log_entries_list.append(f"Error for {file_name}: Cannot load audio file with EasyID3 to set tags: {e}. Skipping tag setting.")
+            return "SUCCESS" # File specific error, but fpcalc worked.
+
+        if title_to_set and "title" in requested_fields:
+            set_title_tag(file_path, title_to_set, False, log_entries_list) # False for not recursive
+        if artist_to_set and "artist" in requested_fields:
+            set_artist_tag(file_path, artist_to_set, False, log_entries_list)
+        if album_to_set and "album" in requested_fields:
+            set_album_tag(file_path, album_to_set, False, log_entries_list)
+        if genre_to_set and "genre" in requested_fields:
+            set_genre_tag(file_path, genre_to_set, False, log_entries_list)
+
+        log_entries_list.append(f"Tag setting process completed for {file_name}.")
+
+    elif api_data.get("status") == "ok" and not api_data.get("results"):
+        log_entries_list.append(f"No results found on AcoustID for {file_name}.")
+    else:
+        error_message = api_data.get("error", {}).get("message", "Unknown error")
+        log_entries_list.append(f"AcoustID API returned status '{api_data.get('status')}' for {file_name}. Error: {error_message}")
+
+    return "SUCCESS"

--- a/tag_album_utils/set_tags.py
+++ b/tag_album_utils/set_tags.py
@@ -1,244 +1,402 @@
 import os
 from mutagen.easyid3 import EasyID3
-from mutagen.id3 import ID3, ID3NoHeaderError, POPM, APIC
+from mutagen.id3 import ID3, ID3NoHeaderError, POPM, APIC, TIT2 # Added TIT2 for title
 from .utils import write_log # Import write_log from utils module
 
-def set_artist_tag(directory, artist_name, recursive):
+# Helper function to handle ID3 header creation consistently
+def _ensure_id3_header(file_path, entries):
+    try:
+        audio = EasyID3(file_path)
+        return audio
+    except ID3NoHeaderError:
+        try:
+            id3 = ID3()
+            # id3.add_tags() # This might not be necessary if EasyID3 can handle it after save.
+            id3.save(file_path)
+            entries.append(f"Info: Created basic ID3 header for {os.path.basename(file_path)}")
+            return EasyID3(file_path) # Now it should be readable
+        except Exception as e:
+            entries.append(f"Skipping file {os.path.basename(file_path)}: Could not create ID3 header: {e}")
+            return None
+    except Exception as e: # Other errors reading the file
+        entries.append(f"Skipping file {os.path.basename(file_path)}: Error reading tags: {e}")
+        return None
+
+def _ensure_id3_header_for_id3_object(file_path, entries):
+    try:
+        audio = ID3(file_path)
+        return audio
+    except ID3NoHeaderError:
+        try:
+            id3 = ID3()
+            id3.save(file_path) # Create file with basic ID3 structure
+            entries.append(f"Info: Created basic ID3 header for {os.path.basename(file_path)}")
+            return ID3(file_path) # Re-open
+        except Exception as e:
+            entries.append(f"Skipping file {os.path.basename(file_path)}: Could not create ID3 header for ID3 object: {e}")
+            return None
+    except Exception as e:
+        entries.append(f"Skipping file {os.path.basename(file_path)}: Error reading tags with ID3: {e}")
+        return None
+
+
+def set_title_tag(path_or_target, title_name, recursive=False, log_entries_list=None):
+    """
+    Sets the 'Title' tag for .mp3 files.
+    Can process a single file or a directory.
+    """
+    current_log_entries = log_entries_list if log_entries_list is not None else []
+    file_name_for_log = os.path.basename(path_or_target) if os.path.isfile(path_or_target) else path_or_target
+
+
+    def process_file(file_path, entries):
+        audio = _ensure_id3_header(file_path, entries)
+        if audio is None:
+            return
+
+        # audio['title'] = title_name # Using EasyID3 'title' key
+        # For TIT2, it's better to use the ID3 object directly if there are issues with EasyID3 mapping
+        try:
+            # Re-open with ID3 to ensure TIT2 frame is handled correctly
+            audio_id3 = ID3(file_path)
+        except ID3NoHeaderError: # Should have been created by _ensure_id3_header, but as a fallback
+            audio_id3 = ID3()
+        except Exception as e:
+            entries.append(f"Skipping file {os.path.basename(file_path)}: Error re-opening with ID3: {e}")
+            return
+
+        audio_id3.delall('TIT2') # Remove existing title frame
+        audio_id3.add(TIT2(encoding=3, text=title_name)) # Add new title frame
+        try:
+            audio_id3.save(file_path)
+            entries.append(f"Set title tag to '{title_name}' for {os.path.basename(file_path)}")
+        except Exception as e:
+            entries.append(f"Error saving title tag for {os.path.basename(file_path)}: {e}")
+
+
+    if os.path.isfile(path_or_target):
+        if path_or_target.lower().endswith('.mp3'):
+            process_file(path_or_target, current_log_entries)
+        else:
+            current_log_entries.append(f"Skipping non-MP3 file: {file_name_for_log}")
+    elif os.path.isdir(path_or_target):
+        if recursive:
+            for root, _, files in os.walk(path_or_target):
+                for file_name in files:
+                    if file_name.lower().endswith('.mp3'):
+                        file_path_full = os.path.join(root, file_name)
+                        process_file(file_path_full, current_log_entries)
+        else:
+            for file_name in os.listdir(path_or_target):
+                file_path_full = os.path.join(path_or_target, file_name)
+                if os.path.isfile(file_path_full) and file_name.lower().endswith('.mp3'):
+                    process_file(file_path_full, current_log_entries)
+    else:
+        current_log_entries.append(f"Error: Path {path_or_target} is not a valid file or directory.")
+
+    if log_entries_list is None: # Only write log if this function is the entry point
+        write_log(current_log_entries, "title_tagging")
+
+
+def set_artist_tag(path_or_target, value, recursive=False, log_entries_list=None):
     """
     Sets the 'Artist' tag for .mp3 files.
+    Can process a single file or a directory.
     """
-    log_entries = []
+    current_log_entries = log_entries_list if log_entries_list is not None else []
+    file_name_for_log = os.path.basename(path_or_target) if os.path.isfile(path_or_target) else path_or_target
 
     def process_file(file_path, entries):
+        audio = _ensure_id3_header(file_path, entries)
+        if audio is None:
+            return
+        audio['artist'] = value
         try:
-            audio = EasyID3(file_path)
-        except ID3NoHeaderError:
-            try:
-                id3 = ID3()
-                id3.save(file_path)
-                audio = EasyID3(file_path)
-            except Exception as e:
-                entries.append(f"Skipping file {file_path}: {e}")
-                return
-        audio['artist'] = artist_name
-        audio.save(file_path)
-        entries.append(f"Set artist tag for {file_path}")
+            audio.save(file_path)
+            entries.append(f"Set artist tag to '{value}' for {os.path.basename(file_path)}")
+        except Exception as e:
+            entries.append(f"Error saving artist tag for {os.path.basename(file_path)}: {e}")
 
-    if recursive:
-        for root, _, files in os.walk(directory):
-            for file in files:
-                if file.lower().endswith('.mp3'):
-                    file_path = os.path.join(root, file)
-                    process_file(file_path, log_entries)
+
+    if os.path.isfile(path_or_target):
+        if path_or_target.lower().endswith('.mp3'):
+            process_file(path_or_target, current_log_entries)
+        else:
+            current_log_entries.append(f"Skipping non-MP3 file: {file_name_for_log}")
+    elif os.path.isdir(path_or_target):
+        if recursive:
+            for root, _, files in os.walk(path_or_target):
+                for file_name in files:
+                    if file_name.lower().endswith('.mp3'):
+                        file_path_full = os.path.join(root, file_name)
+                        process_file(file_path_full, current_log_entries)
+        else:
+            for file_name in os.listdir(path_or_target):
+                file_path_full = os.path.join(path_or_target, file_name)
+                if os.path.isfile(file_path_full) and file_name.lower().endswith('.mp3'):
+                    process_file(file_path_full, current_log_entries)
     else:
-        for file in os.listdir(directory):
-            file_path = os.path.join(directory, file)
-            if os.path.isfile(file_path) and file.lower().endswith('.mp3'):
-                process_file(file_path, log_entries)
-    write_log(log_entries, "artist_tagging")
+        current_log_entries.append(f"Error: Path {path_or_target} is not a valid file or directory.")
+
+    if log_entries_list is None:
+        write_log(current_log_entries, "artist_tagging")
 
 
-def set_album_tag(directory, album_name, recursive):
+def set_album_tag(path_or_target, value, recursive=False, log_entries_list=None):
     """
     Sets the 'Album' tag for .mp3 files.
+    Can process a single file or a directory.
     """
-    log_entries = []
+    current_log_entries = log_entries_list if log_entries_list is not None else []
+    file_name_for_log = os.path.basename(path_or_target) if os.path.isfile(path_or_target) else path_or_target
 
     def process_file(file_path, entries):
+        audio = _ensure_id3_header(file_path, entries)
+        if audio is None:
+            return
+        audio['album'] = value
         try:
-            audio = EasyID3(file_path)
-        except ID3NoHeaderError:
-            try:
-                id3 = ID3()
-                id3.save(file_path)
-                audio = EasyID3(file_path)
-            except Exception as e:
-                entries.append(f"Skipping file {file_path}: {e}")
-                return
-        audio['album'] = album_name
-        audio.save(file_path)
-        entries.append(f"Set album tag for {file_path}")
+            audio.save(file_path)
+            entries.append(f"Set album tag to '{value}' for {os.path.basename(file_path)}")
+        except Exception as e:
+            entries.append(f"Error saving album tag for {os.path.basename(file_path)}: {e}")
 
-    if recursive:
-        for root, _, files in os.walk(directory):
-            for file in files:
-                if file.lower().endswith('.mp3'):
-                    file_path = os.path.join(root, file)
-                    process_file(file_path, log_entries)
+    if os.path.isfile(path_or_target):
+        if path_or_target.lower().endswith('.mp3'):
+            process_file(path_or_target, current_log_entries)
+        else:
+            current_log_entries.append(f"Skipping non-MP3 file: {file_name_for_log}")
+    elif os.path.isdir(path_or_target):
+        if recursive:
+            for root, _, files in os.walk(path_or_target):
+                for file_name in files:
+                    if file_name.lower().endswith('.mp3'):
+                        file_path_full = os.path.join(root, file_name)
+                        process_file(file_path_full, current_log_entries)
+        else:
+            for file_name in os.listdir(path_or_target):
+                file_path_full = os.path.join(path_or_target, file_name)
+                if os.path.isfile(file_path_full) and file_name.lower().endswith('.mp3'):
+                    process_file(file_path_full, current_log_entries)
     else:
-        for file in os.listdir(directory):
-            file_path = os.path.join(directory, file)
-            if os.path.isfile(file_path) and file.lower().endswith('.mp3'):
-                process_file(file_path, log_entries)
-    write_log(log_entries, "album_tagging")
+        current_log_entries.append(f"Error: Path {path_or_target} is not a valid file or directory.")
+
+    if log_entries_list is None:
+        write_log(current_log_entries, "album_tagging")
 
 
-def set_genre_tag(directory, genre_name, recursive):
+def set_genre_tag(path_or_target, value, recursive=False, log_entries_list=None):
     """
     Sets the 'Genre' tag for .mp3 files.
+    Can process a single file or a directory.
     """
-    log_entries = []
+    current_log_entries = log_entries_list if log_entries_list is not None else []
+    file_name_for_log = os.path.basename(path_or_target) if os.path.isfile(path_or_target) else path_or_target
 
     def process_file(file_path, entries):
+        audio = _ensure_id3_header(file_path, entries)
+        if audio is None:
+            return
+        audio['genre'] = value
         try:
-            audio = EasyID3(file_path)
-        except ID3NoHeaderError:
-            try:
-                id3 = ID3()
-                id3.save(file_path)
-                audio = EasyID3(file_path)
-            except Exception as e:
-                entries.append(f"Skipping file {file_path}: {e}")
-                return
-        audio['genre'] = genre_name
-        audio.save(file_path)
-        entries.append(f"Set genre tag for {file_path}")
+            audio.save(file_path)
+            entries.append(f"Set genre tag to '{value}' for {os.path.basename(file_path)}")
+        except Exception as e:
+            entries.append(f"Error saving genre tag for {os.path.basename(file_path)}: {e}")
 
-    if recursive:
-        for root, _, files in os.walk(directory):
-            for file in files:
-                if file.lower().endswith('.mp3'):
-                    file_path = os.path.join(root, file)
-                    process_file(file_path, log_entries)
+    if os.path.isfile(path_or_target):
+        if path_or_target.lower().endswith('.mp3'):
+            process_file(path_or_target, current_log_entries)
+        else:
+            current_log_entries.append(f"Skipping non-MP3 file: {file_name_for_log}")
+    elif os.path.isdir(path_or_target):
+        if recursive:
+            for root, _, files in os.walk(path_or_target):
+                for file_name in files:
+                    if file_name.lower().endswith('.mp3'):
+                        file_path_full = os.path.join(root, file_name)
+                        process_file(file_path_full, current_log_entries)
+        else:
+            for file_name in os.listdir(path_or_target):
+                file_path_full = os.path.join(path_or_target, file_name)
+                if os.path.isfile(file_path_full) and file_name.lower().endswith('.mp3'):
+                    process_file(file_path_full, current_log_entries)
     else:
-        for file in os.listdir(directory):
-            file_path = os.path.join(directory, file)
-            if os.path.isfile(file_path) and file.lower().endswith('.mp3'):
-                process_file(file_path, log_entries)
-    write_log(log_entries, "genre_tagging")
+        current_log_entries.append(f"Error: Path {path_or_target} is not a valid file or directory.")
+
+    if log_entries_list is None:
+        write_log(current_log_entries, "genre_tagging")
 
 
-def set_rating_tag(directory, rating, recursive):
+def set_rating_tag(path_or_target, value, recursive=False, log_entries_list=None):
     """
     Sets a user-defined rating (1-5) for .mp3 files using the POPM frame.
+    Can process a single file or a directory.
     """
-    log_entries = []
+    current_log_entries = log_entries_list if log_entries_list is not None else []
+    file_name_for_log = os.path.basename(path_or_target) if os.path.isfile(path_or_target) else path_or_target
+
     rating_map = {1: 1, 2: 64, 3: 128, 4: 196, 5: 255}
-    popm_rating = rating_map.get(rating, 0)
+    popm_rating = rating_map.get(value, 0) # value is the rating here
 
     def process_file(file_path, entries):
-        try:
-            audio = ID3(file_path)
-        except ID3NoHeaderError:
-            try:
-                audio = ID3()
-                audio.add_tags()
-                audio.save(file_path)
-                audio = ID3(file_path)
-            except Exception as e:
-                entries.append(f"Skipping file {file_path}: {e}")
-                return
+        audio = _ensure_id3_header_for_id3_object(file_path, entries)
+        if audio is None:
+            return
         audio.delall('POPM')
-        audio.add(POPM(email='user@example.com', rating=popm_rating, count=0))
-        audio.save(file_path)
-        entries.append(f"Set rating {rating} for {file_path}")
+        audio.add(POPM(email='user@example.com', rating=popm_rating, count=0)) # Using popm_rating based on input 'value'
+        try:
+            audio.save(file_path)
+            entries.append(f"Set rating to {value} for {os.path.basename(file_path)}")
+        except Exception as e:
+            entries.append(f"Error saving rating for {os.path.basename(file_path)}: {e}")
 
-    if recursive:
-        for root, _, files in os.walk(directory):
-            for file in files:
-                if file.lower().endswith('.mp3'):
-                    file_path = os.path.join(root, file)
-                    process_file(file_path, log_entries)
+    if os.path.isfile(path_or_target):
+        if path_or_target.lower().endswith('.mp3'):
+            process_file(path_or_target, current_log_entries)
+        else:
+            current_log_entries.append(f"Skipping non-MP3 file: {file_name_for_log}")
+    elif os.path.isdir(path_or_target):
+        if recursive:
+            for root, _, files in os.walk(path_or_target):
+                for file_name in files:
+                    if file_name.lower().endswith('.mp3'):
+                        file_path_full = os.path.join(root, file_name)
+                        process_file(file_path_full, current_log_entries)
+        else:
+            for file_name in os.listdir(path_or_target):
+                file_path_full = os.path.join(path_or_target, file_name)
+                if os.path.isfile(file_path_full) and file_name.lower().endswith('.mp3'):
+                    process_file(file_path_full, current_log_entries)
     else:
-        for file in os.listdir(directory):
-            file_path = os.path.join(directory, file)
-            if os.path.isfile(file_path) and file.lower().endswith('.mp3'):
-                process_file(file_path, log_entries)
-    write_log(log_entries, "rating_tagging")
+        current_log_entries.append(f"Error: Path {path_or_target} is not a valid file or directory.")
+
+    if log_entries_list is None:
+        write_log(current_log_entries, "rating_tagging")
 
 
-def set_cover_art(directory, image_path, recursive):
+def set_cover_art(path_or_target, image_path_or_data, recursive=False, log_entries_list=None): # Renamed to match, but parameter is image_path
     """
     Embeds cover art (JPG/PNG) into .mp3 files.
+    Can process a single file or a directory. image_path_or_data is path to image for now.
     """
-    log_entries = []
-    ext = os.path.splitext(image_path)[1].lower()
+    current_log_entries = log_entries_list if log_entries_list is not None else []
+    file_name_for_log = os.path.basename(path_or_target) if os.path.isfile(path_or_target) else path_or_target
+
+    # This part needs to be outside process_file if image_path_or_data is a path
+    # If it were image_data, it could be passed directly to process_file.
+    # For now, assume image_path_or_data is a file path.
+    if not isinstance(image_path_or_data, str) or not os.path.exists(image_path_or_data):
+        msg = f"Cover art path '{image_path_or_data}' is invalid or not a string."
+        current_log_entries.append(msg)
+        if log_entries_list is None: print(msg) # Print if standalone
+        if log_entries_list is None: write_log(current_log_entries, "coverart_tagging_error")
+        return
+
+    ext = os.path.splitext(image_path_or_data)[1].lower()
     if ext == '.jpg' or ext == '.jpeg':
         mime = 'image/jpeg'
     elif ext == '.png':
         mime = 'image/png'
     else:
-        log_entries.append(f"Unsupported image format for {image_path}. Use JPG or PNG.")
-        # Print to console as well, as this is a user-facing issue
-        print(f"Unsupported image format for {image_path}. Use JPG or PNG.")
-        if log_entries: write_log(log_entries, "coverart_tagging_error")
+        msg = f"Unsupported image format for {image_path_or_data}. Use JPG or PNG."
+        current_log_entries.append(msg)
+        if log_entries_list is None: print(msg)
+        if log_entries_list is None: write_log(current_log_entries, "coverart_tagging_error")
         return
+
     try:
-        with open(image_path, 'rb') as img_in:
+        with open(image_path_or_data, 'rb') as img_in:
             img_data = img_in.read()
     except Exception as e:
-        log_entries.append(f"Failed to read image file {image_path}: {e}")
-        print(f"Failed to read image file {image_path}: {e}")
-        if log_entries: write_log(log_entries, "coverart_tagging_error")
+        msg = f"Failed to read image file {image_path_or_data}: {e}"
+        current_log_entries.append(msg)
+        if log_entries_list is None: print(msg)
+        if log_entries_list is None: write_log(current_log_entries, "coverart_tagging_error")
         return
 
     def process_file(file_path, entries):
-        try:
-            audio = ID3(file_path)
-        except ID3NoHeaderError:
-            try:
-                audio = ID3()
-                audio.add_tags()
-                audio.save(file_path)
-                audio = ID3(file_path)
-            except Exception as e:
-                entries.append(f"Skipping file {file_path}: {e}")
-                return
+        audio = _ensure_id3_header_for_id3_object(file_path, entries)
+        if audio is None:
+            return
+
         audio.delall('APIC')
         audio.add(APIC(
             encoding=3,
-            mime=mime,
+            mime=mime, # mime determined outside
             type=3,
             desc='Cover',
-            data=img_data
+            data=img_data # img_data read outside
         ))
-        audio.save(file_path)
-        entries.append(f"Embedded cover art for {file_path}")
+        try:
+            audio.save(file_path)
+            entries.append(f"Embedded cover art from {os.path.basename(image_path_or_data)} into {os.path.basename(file_path)}")
+        except Exception as e:
+            entries.append(f"Error saving cover art for {os.path.basename(file_path)}: {e}")
 
-    if recursive:
-        for root, _, files in os.walk(directory):
-            for file in files:
-                if file.lower().endswith('.mp3'):
-                    file_path = os.path.join(root, file)
-                    process_file(file_path, log_entries)
+
+    if os.path.isfile(path_or_target):
+        if path_or_target.lower().endswith('.mp3'):
+            process_file(path_or_target, current_log_entries)
+        else:
+            current_log_entries.append(f"Skipping non-MP3 file for cover art: {file_name_for_log}")
+    elif os.path.isdir(path_or_target):
+        if recursive:
+            for root, _, files in os.walk(path_or_target):
+                for file_name in files:
+                    if file_name.lower().endswith('.mp3'):
+                        file_path_full = os.path.join(root, file_name)
+                        process_file(file_path_full, current_log_entries)
+        else:
+            for file_name in os.listdir(path_or_target):
+                file_path_full = os.path.join(path_or_target, file_name)
+                if os.path.isfile(file_path_full) and file_name.lower().endswith('.mp3'):
+                    process_file(file_path_full, current_log_entries)
     else:
-        for file in os.listdir(directory):
-            file_path = os.path.join(directory, file)
-            if os.path.isfile(file_path) and file.lower().endswith('.mp3'):
-                process_file(file_path, log_entries)
-    write_log(log_entries, "coverart_tagging")
+        current_log_entries.append(f"Error: Path {path_or_target} is not a valid file or directory for cover art.")
+
+    if log_entries_list is None:
+        write_log(current_log_entries, "coverart_tagging")
 
 
-def set_year_tag(directory, year_value, recursive):
+def set_year_tag(path_or_target, value, recursive=False, log_entries_list=None):
     """
-    Sets the 'Year' tag for .mp3 files.
+    Sets the 'Year' tag for .mp3 files (using 'date' key in EasyID3).
+    Can process a single file or a directory.
     """
-    log_entries = []
+    current_log_entries = log_entries_list if log_entries_list is not None else []
+    file_name_for_log = os.path.basename(path_or_target) if os.path.isfile(path_or_target) else path_or_target
 
     def process_file(file_path, entries):
+        audio = _ensure_id3_header(file_path, entries)
+        if audio is None:
+            return
+        audio['date'] = str(value) # Ensure year is string for EasyID3 'date'
         try:
-            audio = EasyID3(file_path)
-        except ID3NoHeaderError:
-            try:
-                id3 = ID3()
-                id3.save(file_path)
-                audio = EasyID3(file_path)
-            except Exception as e:
-                entries.append(f"Skipping file {file_path}: {e}")
-                return
-        audio['date'] = year_value
-        audio.save(file_path)
-        entries.append(f"Set year tag to {year_value} for {file_path}")
+            audio.save(file_path)
+            entries.append(f"Set year tag to '{value}' for {os.path.basename(file_path)}")
+        except Exception as e:
+            entries.append(f"Error saving year tag for {os.path.basename(file_path)}: {e}")
 
-    if recursive:
-        for root, _, files in os.walk(directory):
-            for file in files:
-                if file.lower().endswith('.mp3'):
-                    file_path = os.path.join(root, file)
-                    process_file(file_path, log_entries)
+    if os.path.isfile(path_or_target):
+        if path_or_target.lower().endswith('.mp3'):
+            process_file(path_or_target, current_log_entries)
+        else:
+            current_log_entries.append(f"Skipping non-MP3 file: {file_name_for_log}")
+    elif os.path.isdir(path_or_target):
+        if recursive:
+            for root, _, files in os.walk(path_or_target):
+                for file_name in files:
+                    if file_name.lower().endswith('.mp3'):
+                        file_path_full = os.path.join(root, file_name)
+                        process_file(file_path_full, current_log_entries)
+        else:
+            for file_name in os.listdir(path_or_target):
+                file_path_full = os.path.join(path_or_target, file_name)
+                if os.path.isfile(file_path_full) and file_name.lower().endswith('.mp3'):
+                    process_file(file_path_full, current_log_entries)
     else:
-        for file in os.listdir(directory):
-            file_path = os.path.join(directory, file)
-            if os.path.isfile(file_path) and file.lower().endswith('.mp3'):
-                process_file(file_path, log_entries)
-    write_log(log_entries, "year_tagging")
+        current_log_entries.append(f"Error: Path {path_or_target} is not a valid file or directory.")
+
+    if log_entries_list is None:
+        write_log(current_log_entries, "year_tagging")

--- a/test/test_tag_album.py
+++ b/test/test_tag_album.py
@@ -357,3 +357,179 @@ class TestRecursiveBehavior(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
+
+
+import tempfile # For TestAcoustidFetching
+
+# Need to import the function to be tested
+from tag_album_utils.fetch_metadata import fetch_metadata_from_acoustid
+
+class TestAcoustidFetching(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        # Use the existing test-music.mp3. Ensure it's copied from the correct relative path.
+        original_mp3_src_path = os.path.join(os.path.dirname(__file__), 'test-music.mp3')
+        self.test_mp3_path = os.path.join(self.temp_dir, "test_acoustid.mp3")
+
+        if os.path.exists(original_mp3_src_path):
+            shutil.copy(original_mp3_src_path, self.test_mp3_path)
+            # Ensure the copied file has some basic ID3 structure for EasyID3 to work reliably
+            # or for the setters to create one.
+            try:
+                # Try to clear tags that might interfere, especially if test-music.mp3 has prior tags
+                audio = EasyID3(self.test_mp3_path)
+                for key in list(audio.keys()): # list() to avoid RuntimeError for changing dict size
+                    del audio[key]
+                audio.save()
+            except ID3NoHeaderError: # If no header, it's fine, setters will handle it
+                # Attempt to create one so EasyID3 can open it later for assertions
+                try:
+                    id3 = ID3()
+                    id3.save(self.test_mp3_path)
+                except Exception as e_save:
+                    print(f"Warning: Could not create initial ID3 header for {self.test_mp3_path} in setUp: {e_save}")
+            except Exception as e:
+                print(f"Warning: Could not clear tags for {self.test_mp3_path} in setUp: {e}")
+        else:
+            # Fallback if test-music.mp3 is missing (shouldn't happen in CI if repo is complete)
+            with open(self.test_mp3_path, 'wb') as f:
+                f.write(b'\xFF\xFB\x10\xC0' + b'\x00' * 10240) # Dummy MP3 data
+            try:
+                ID3().save(self.test_mp3_path) # Create a basic ID3 header
+            except Exception as e:
+                 print(f"Warning: Could not create fallback ID3 header for {self.test_mp3_path} in setUp: {e}")
+
+
+        self.api_key = "MDCUvH3Ppp" # As used in main script
+        self.sample_fpcalc_output_str = '{"duration": 180, "fingerprint": "some_fingerprint_string"}'
+        self.sample_fpcalc_output_json = {"duration": 180, "fingerprint": "some_fingerprint_string"}
+
+        self.sample_acoustid_response_json = {
+            "status": "ok",
+            "results": [{
+                "score": 0.9,
+                "id": "some_acoustid_id",
+                "recordings": [{
+                    "title": "Test Title from AcoustID",
+                    "duration": 180,
+                    "artists": [{"name": "Test Artist from AcoustID"}],
+                    "genres": [{"name": "Electronic"}]
+                }],
+                "releasegroups": [{
+                    "title": "Test Album from AcoustID",
+                    "type": "Album"
+                }]
+            }]
+        }
+        # Ensure logs directory exists for any direct calls to setters that might log independently
+        # although fetch_metadata_from_acoustid should manage its own log list.
+        os.makedirs("logs", exist_ok=True)
+
+
+    def tearDown(self):
+        if hasattr(self, 'temp_dir') and os.path.exists(self.temp_dir):
+            shutil.rmtree(self.temp_dir)
+
+    @patch('tag_album_utils.fetch_metadata.requests.get')
+    @patch('tag_album_utils.fetch_metadata.subprocess.run')
+    def test_fetch_and_set_acoustid_tags_success(self, mock_subprocess_run, mock_requests_get):
+
+        def subprocess_run_side_effect(*args, **kwargs):
+            cmd = args[0]
+            if cmd == ['fpcalc', '-version']:
+                return MagicMock(returncode=0, stdout="fpcalc version 1.5.1", stderr="")
+            elif cmd == ['fpcalc', '-json', self.test_mp3_path]:
+                return MagicMock(returncode=0, stdout=self.sample_fpcalc_output_str, stderr="")
+            return MagicMock(returncode=1, stdout="", stderr="Unknown command for mock_subprocess_run")
+
+        mock_subprocess_run.side_effect = subprocess_run_side_effect
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = self.sample_acoustid_response_json
+        mock_response.status_code = 200
+        mock_response.raise_for_status = MagicMock() # Ensure it doesn't raise for 200
+        mock_requests_get.return_value = mock_response
+
+        log_entries = []
+        status = fetch_metadata_from_acoustid(self.test_mp3_path, self.api_key,
+                                              ["title", "artist", "album", "genre"], log_entries)
+
+        self.assertEqual(status, "SUCCESS", f"Function returned {status} with logs: {log_entries}")
+
+        # Assert subprocess.run calls
+        call_fpcalc_version = call(['fpcalc', '-version'], capture_output=True, text=True, check=False, timeout=5)
+        call_fpcalc_json = call(['fpcalc', '-json', self.test_mp3_path], capture_output=True, text=True, check=False, timeout=15) # check=False due to recent change
+        mock_subprocess_run.assert_has_calls([call_fpcalc_version, call_fpcalc_json], any_order=True) # any_order might be true if other calls were made, but specific calls must exist
+
+        # Assert requests.get call
+        mock_requests_get.assert_called_once()
+        actual_call_args = mock_requests_get.call_args
+        self.assertEqual(actual_call_args[0][0], "https://api.acoustid.org/v2/lookup")
+
+        expected_params = {
+            "client": self.api_key,
+            "meta": "recordings,releasegroups,compress,recordingids", # Adjusted based on requested fields
+            "duration": str(self.sample_fpcalc_output_json["duration"]),
+            "fingerprint": self.sample_fpcalc_output_json["fingerprint"]
+        }
+        # Normalize meta param for comparison by splitting, sorting, and rejoining
+        actual_meta_set = set(actual_call_args[1]['params']['meta'].split(','))
+        expected_meta_set = set(expected_params['meta'].split(','))
+        self.assertEqual(actual_meta_set, expected_meta_set, "Meta parameters do not match")
+
+        self.assertEqual(actual_call_args[1]['params']['client'], expected_params['client'])
+        self.assertEqual(actual_call_args[1]['params']['duration'], expected_params['duration'])
+        self.assertEqual(actual_call_args[1]['params']['fingerprint'], expected_params['fingerprint'])
+
+        # Assert tags were written
+        try:
+            audio = EasyID3(self.test_mp3_path)
+            self.assertEqual(audio.get('title'), ["Test Title from AcoustID"])
+            self.assertEqual(audio.get('artist'), ["Test Artist from AcoustID"])
+            self.assertEqual(audio.get('album'), ["Test Album from AcoustID"])
+            self.assertEqual(audio.get('genre'), ["Electronic"])
+        except Exception as e:
+            self.fail(f"Failed to read tags from MP3 after AcoustID processing: {e}\nLogs: {log_entries}")
+
+
+    @patch('tag_album_utils.fetch_metadata.requests.get')
+    @patch('tag_album_utils.fetch_metadata.subprocess.run')
+    def test_fetch_metadata_fpcalc_not_found(self, mock_subprocess_run, mock_requests_get):
+        # Simulate fpcalc -version failing (e.g., FileNotFoundError or non-zero return)
+        mock_subprocess_run.return_value = MagicMock(returncode=1, stderr="fpcalc not found")
+        # Or, to simulate FileNotFoundError directly for the first call:
+        # mock_subprocess_run.side_effect = FileNotFoundError("fpcalc not found at path")
+
+        log_entries = []
+        status = fetch_metadata_from_acoustid(self.test_mp3_path, self.api_key,
+                                              ["title", "artist"], log_entries)
+
+        self.assertEqual(status, "FPCLAC_NOT_FOUND")
+        mock_requests_get.assert_not_called()
+        # Check that a critical log message was added
+        self.assertTrue(any("CRITICAL: fpcalc not found" in entry for entry in log_entries),
+                        f"Critical fpcalc error not found in logs: {log_entries}")
+
+    @patch('tag_album_utils.fetch_metadata.requests.get')
+    @patch('tag_album_utils.fetch_metadata.subprocess.run')
+    def test_fetch_metadata_fpcalc_json_error(self, mock_subprocess_run, mock_requests_get):
+        # First call for version check is successful
+        # Second call for JSON output fails
+        def subprocess_run_side_effect(*args, **kwargs):
+            cmd = args[0]
+            if cmd == ['fpcalc', '-version']:
+                return MagicMock(returncode=0, stdout="fpcalc version 1.5.1", stderr="")
+            elif cmd == ['fpcalc', '-json', self.test_mp3_path]:
+                return MagicMock(returncode=1, stdout="", stderr="Error during fpcalc JSON generation") # Simulate fpcalc error
+            return MagicMock(returncode=1, stdout="", stderr="Unknown command")
+
+        mock_subprocess_run.side_effect = subprocess_run_side_effect
+
+        log_entries = []
+        status = fetch_metadata_from_acoustid(self.test_mp3_path, self.api_key,
+                                              ["title", "artist"], log_entries)
+
+        self.assertEqual(status, "FPCLAC_ERROR")
+        mock_requests_get.assert_not_called()
+        self.assertTrue(any("fpcalc execution failed" in entry for entry in log_entries),
+                        f"FPCLAC_ERROR not logged correctly: {log_entries}")


### PR DESCRIPTION
This commit introduces a new feature to fetch and set MP3 tags using the AcoustID service.

New command-line options:
- `--fetch-and-set-acoustid-tags`: Enables fetching tags from AcoustID.
- `--fields`: Specifies a comma-separated list of tags to fetch (e.g., "title,artist,album,genre").

Key changes:
- Added logic to `tag_album.py` to handle the new options.
- Implemented `fetch_metadata_from_acoustid` in `tag_album_utils/fetch_metadata.py`. This function:
    - Uses the `fpcalc` command-line tool to generate audio fingerprints and get track duration.
    - Checks for `fpcalc` availability and provides feedback to you if missing.
    - Calls the AcoustID API (`/v2/lookup`) with the fingerprint, duration, API key, and requested metadata.
    - Parses the API response and extracts the highest-scoring match.
    - Calls tag setting functions to apply the fetched metadata.
- Updated tag setting functions in `tag_album_utils/set_tags.py` to be more flexible (handle single files, accept external log lists) and added a `set_title_tag` function.
- Added comprehensive unit tests in `test/test_tag_album.py` for the AcoustID functionality, mocking `fpcalc` and API calls.
- Updated `README.md` to document the new feature, options, and the `fpcalc` dependency (installable via `libchromaprint-tools` or similar).

The AcoustID API key is currently hardcoded as provided in the issue. The script now depends on `fpcalc` being installed and in the PATH for this feature to work.